### PR TITLE
update deprecated code

### DIFF
--- a/lib/config/theme.dart
+++ b/lib/config/theme.dart
@@ -17,7 +17,6 @@ ThemeData lightTheme(ColorScheme? dynamicColorScheme) => ThemeData(
     textColor: dynamicColorScheme != null ? dynamicColorScheme.onSurfaceVariant : const Color.fromRGBO(117, 117, 117, 1),
     iconColor: dynamicColorScheme != null ? dynamicColorScheme.onSurfaceVariant : const Color.fromRGBO(117, 117, 117, 1),
   ),
-  androidOverscrollIndicator: AndroidOverscrollIndicator.stretch,
 );
 
 ThemeData darkTheme(ColorScheme? dynamicColorScheme) => ThemeData(
@@ -36,7 +35,6 @@ ThemeData darkTheme(ColorScheme? dynamicColorScheme) => ThemeData(
     textColor: dynamicColorScheme != null ? dynamicColorScheme.onSurfaceVariant : const Color.fromRGBO(187, 187, 187, 1),
     iconColor: dynamicColorScheme != null ? dynamicColorScheme.onSurfaceVariant : const Color.fromRGBO(187, 187, 187, 1),
   ),
-  androidOverscrollIndicator: AndroidOverscrollIndicator.stretch,
 );
 
 ThemeData lightThemeOldVersions() => ThemeData(
@@ -55,7 +53,6 @@ ThemeData lightThemeOldVersions() => ThemeData(
     iconColor: Color.fromRGBO(117, 117, 117, 1),
   ),
   brightness: Brightness.light,
-  androidOverscrollIndicator: AndroidOverscrollIndicator.stretch
 );
 
 ThemeData darkThemeOldVersions() => ThemeData(
@@ -77,5 +74,4 @@ ThemeData darkThemeOldVersions() => ThemeData(
     iconColor: Color.fromRGBO(187, 187, 187, 1),
   ),
   brightness: Brightness.dark,
-  androidOverscrollIndicator: AndroidOverscrollIndicator.stretch
 );

--- a/lib/screens/home/disable_modal.dart
+++ b/lib/screens/home/disable_modal.dart
@@ -165,7 +165,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 0
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyLarge!.color
+                                        : Theme.of(context).colorScheme.onSurfaceVariant
                                     ),
                                     child: Text(AppLocalizations.of(context)!.seconds30),
                                   ),
@@ -191,7 +191,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 1
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyLarge!.color
+                                        : Theme.of(context).colorScheme.onSurfaceVariant
                                     ),
                                     child: Text(AppLocalizations.of(context)!.minute1),
                                   ),
@@ -221,7 +221,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 2
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyLarge!.color
+                                        : Theme.of(context).colorScheme.onSurfaceVariant
                                     ),
                                     child: Text(AppLocalizations.of(context)!.minutes2),
                                   ),
@@ -247,7 +247,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 3
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyLarge!.color
+                                        : Theme.of(context).colorScheme.onSurfaceVariant
                                     ),
                                     child: Text(AppLocalizations.of(context)!.minutes5),
                                   ),
@@ -277,7 +277,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 4
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyLarge!.color
+                                        : Theme.of(context).colorScheme.onSurfaceVariant
                                     ),
                                     child: Text(AppLocalizations.of(context)!.indefinitely),
                                   ),
@@ -303,7 +303,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 5
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyLarge!.color
+                                        : Theme.of(context).colorScheme.onSurfaceVariant
                                     ),
                                     child: Text(AppLocalizations.of(context)!.custom),
                                   ),

--- a/lib/screens/home/disable_modal.dart
+++ b/lib/screens/home/disable_modal.dart
@@ -165,7 +165,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 0
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyText1!.color
+                                        : Theme.of(context).textTheme.bodyLarge!.color
                                     ),
                                     child: Text(AppLocalizations.of(context)!.seconds30),
                                   ),
@@ -191,7 +191,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 1
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyText1!.color
+                                        : Theme.of(context).textTheme.bodyLarge!.color
                                     ),
                                     child: Text(AppLocalizations.of(context)!.minute1),
                                   ),
@@ -221,7 +221,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 2
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyText1!.color
+                                        : Theme.of(context).textTheme.bodyLarge!.color
                                     ),
                                     child: Text(AppLocalizations.of(context)!.minutes2),
                                   ),
@@ -247,7 +247,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 3
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyText1!.color
+                                        : Theme.of(context).textTheme.bodyLarge!.color
                                     ),
                                     child: Text(AppLocalizations.of(context)!.minutes5),
                                   ),
@@ -277,7 +277,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 4
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyText1!.color
+                                        : Theme.of(context).textTheme.bodyLarge!.color
                                     ),
                                     child: Text(AppLocalizations.of(context)!.indefinitely),
                                   ),
@@ -303,7 +303,7 @@ class _DisableModalState extends State<DisableModal> {
                                       fontSize: 14,
                                       color: selectedOption == 5
                                         ? Theme.of(context).colorScheme.primary
-                                        : Theme.of(context).textTheme.bodyText1!.color
+                                        : Theme.of(context).textTheme.bodyLarge!.color
                                     ),
                                     child: Text(AppLocalizations.of(context)!.custom),
                                   ),

--- a/lib/screens/settings/advanced_settings/statistics_visualization_modal.dart
+++ b/lib/screens/settings/advanced_settings/statistics_visualization_modal.dart
@@ -52,7 +52,7 @@ class StatisticsVisualizationModal extends StatelessWidget {
                     size: 50,
                     color: value == appConfigProvider.statisticsVisualizationMode
                       ? Theme.of(context).colorScheme.primary
-                      : Theme.of(context).textTheme.bodyText1!.color
+                      : Theme.of(context).textTheme.bodyLarge!.color
                   ),
                   const SizedBox(width: 30),
                   Column(
@@ -65,7 +65,7 @@ class StatisticsVisualizationModal extends StatelessWidget {
                           fontWeight: FontWeight.bold,
                           color: value == appConfigProvider.statisticsVisualizationMode
                             ? Theme.of(context).colorScheme.primary
-                            : Theme.of(context).textTheme.bodyText1!.color
+                            : Theme.of(context).textTheme.bodyLarge!.color
                         ),
                       ),
                       const SizedBox(height: 10),
@@ -76,7 +76,7 @@ class StatisticsVisualizationModal extends StatelessWidget {
                           style: TextStyle(
                             color: value == appConfigProvider.statisticsVisualizationMode
                               ? Theme.of(context).colorScheme.primary
-                              : Theme.of(context).textTheme.bodyText1!.color
+                              : Theme.of(context).textTheme.bodyLarge!.color
                           ),
                         ),
                       )

--- a/lib/screens/settings/advanced_settings/statistics_visualization_modal.dart
+++ b/lib/screens/settings/advanced_settings/statistics_visualization_modal.dart
@@ -52,7 +52,7 @@ class StatisticsVisualizationModal extends StatelessWidget {
                     size: 50,
                     color: value == appConfigProvider.statisticsVisualizationMode
                       ? Theme.of(context).colorScheme.primary
-                      : Theme.of(context).textTheme.bodyLarge!.color
+                      : Theme.of(context).colorScheme.onSurfaceVariant
                   ),
                   const SizedBox(width: 30),
                   Column(
@@ -65,7 +65,7 @@ class StatisticsVisualizationModal extends StatelessWidget {
                           fontWeight: FontWeight.bold,
                           color: value == appConfigProvider.statisticsVisualizationMode
                             ? Theme.of(context).colorScheme.primary
-                            : Theme.of(context).textTheme.bodyLarge!.color
+                            : Theme.of(context).colorScheme.onSurfaceVariant
                         ),
                       ),
                       const SizedBox(height: 10),
@@ -76,7 +76,7 @@ class StatisticsVisualizationModal extends StatelessWidget {
                           style: TextStyle(
                             color: value == appConfigProvider.statisticsVisualizationMode
                               ? Theme.of(context).colorScheme.primary
-                              : Theme.of(context).textTheme.bodyLarge!.color
+                              : Theme.of(context).colorScheme.onSurfaceVariant
                           ),
                         ),
                       )

--- a/lib/screens/settings/auto_refresh_time_modal.dart
+++ b/lib/screens/settings/auto_refresh_time_modal.dart
@@ -204,7 +204,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 0
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyLarge!.color
+                                      : Theme.of(context).colorScheme.onSurfaceVariant
                                   ),
                                   child: Text(AppLocalizations.of(context)!.second1),
                                 ),
@@ -230,7 +230,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 1
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyLarge!.color
+                                      : Theme.of(context).colorScheme.onSurfaceVariant
                                   ),
                                   child: Text(AppLocalizations.of(context)!.seconds2),
                                 ),
@@ -261,7 +261,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 2
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyLarge!.color
+                                      : Theme.of(context).colorScheme.onSurfaceVariant
                                   ),
                                   child: Text(AppLocalizations.of(context)!.seconds5),
                                 ),
@@ -287,7 +287,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 3
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyLarge!.color
+                                      : Theme.of(context).colorScheme.onSurfaceVariant
                                   ),
                                   child: Text(AppLocalizations.of(context)!.seconds10),
                                 ),
@@ -318,7 +318,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 4
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyLarge!.color
+                                      : Theme.of(context).colorScheme.onSurfaceVariant
                                   ),
                                   child: Text(AppLocalizations.of(context)!.seconds30),
                                 ),
@@ -344,7 +344,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 5
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyLarge!.color
+                                      : Theme.of(context).colorScheme.onSurfaceVariant
                                   ),
                                   child: Text(AppLocalizations.of(context)!.custom),
                                 ),

--- a/lib/screens/settings/auto_refresh_time_modal.dart
+++ b/lib/screens/settings/auto_refresh_time_modal.dart
@@ -204,7 +204,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 0
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyText1!.color
+                                      : Theme.of(context).textTheme.bodyLarge!.color
                                   ),
                                   child: Text(AppLocalizations.of(context)!.second1),
                                 ),
@@ -230,7 +230,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 1
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyText1!.color
+                                      : Theme.of(context).textTheme.bodyLarge!.color
                                   ),
                                   child: Text(AppLocalizations.of(context)!.seconds2),
                                 ),
@@ -261,7 +261,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 2
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyText1!.color
+                                      : Theme.of(context).textTheme.bodyLarge!.color
                                   ),
                                   child: Text(AppLocalizations.of(context)!.seconds5),
                                 ),
@@ -287,7 +287,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 3
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyText1!.color
+                                      : Theme.of(context).textTheme.bodyLarge!.color
                                   ),
                                   child: Text(AppLocalizations.of(context)!.seconds10),
                                 ),
@@ -318,7 +318,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 4
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyText1!.color
+                                      : Theme.of(context).textTheme.bodyLarge!.color
                                   ),
                                   child: Text(AppLocalizations.of(context)!.seconds30),
                                 ),
@@ -344,7 +344,7 @@ class _AutoRefreshTimeModalState extends State<AutoRefreshTimeModal> {
                                     fontSize: 14,
                                     color: selectedOption == 5
                                       ? Theme.of(context).colorScheme.primary
-                                      : Theme.of(context).textTheme.bodyText1!.color
+                                      : Theme.of(context).textTheme.bodyLarge!.color
                                   ),
                                   child: Text(AppLocalizations.of(context)!.custom),
                                 ),

--- a/lib/screens/settings/logs_quantity_load_modal.dart
+++ b/lib/screens/settings/logs_quantity_load_modal.dart
@@ -194,7 +194,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 0
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyLarge!.color
+                                  : Theme.of(context).colorScheme.onSurfaceVariant
                               ),
                               child: Text(AppLocalizations.of(context)!.minutes30),
                             ),
@@ -220,7 +220,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 1
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyLarge!.color
+                                  : Theme.of(context).colorScheme.onSurfaceVariant
                               ),
                               child: Text(AppLocalizations.of(context)!.hour1),
                             ),
@@ -251,7 +251,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 2
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyLarge!.color
+                                  : Theme.of(context).colorScheme.onSurfaceVariant
                               ),
                               child: Text(AppLocalizations.of(context)!.hours2),
                             ),
@@ -277,7 +277,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 3
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyLarge!.color
+                                  : Theme.of(context).colorScheme.onSurfaceVariant
                               ),
                               child: Text(AppLocalizations.of(context)!.hours4),
                             ),
@@ -308,7 +308,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 4
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyLarge!.color
+                                  : Theme.of(context).colorScheme.onSurfaceVariant
                               ),
                               child: Text(AppLocalizations.of(context)!.hours6),
                             ),
@@ -334,7 +334,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 5
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyLarge!.color
+                                  : Theme.of(context).colorScheme.onSurfaceVariant
                               ),
                               child: Text(AppLocalizations.of(context)!.hours8),
                             ),

--- a/lib/screens/settings/logs_quantity_load_modal.dart
+++ b/lib/screens/settings/logs_quantity_load_modal.dart
@@ -194,7 +194,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 0
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyText1!.color
+                                  : Theme.of(context).textTheme.bodyLarge!.color
                               ),
                               child: Text(AppLocalizations.of(context)!.minutes30),
                             ),
@@ -220,7 +220,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 1
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyText1!.color
+                                  : Theme.of(context).textTheme.bodyLarge!.color
                               ),
                               child: Text(AppLocalizations.of(context)!.hour1),
                             ),
@@ -251,7 +251,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 2
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyText1!.color
+                                  : Theme.of(context).textTheme.bodyLarge!.color
                               ),
                               child: Text(AppLocalizations.of(context)!.hours2),
                             ),
@@ -277,7 +277,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 3
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyText1!.color
+                                  : Theme.of(context).textTheme.bodyLarge!.color
                               ),
                               child: Text(AppLocalizations.of(context)!.hours4),
                             ),
@@ -308,7 +308,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 4
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyText1!.color
+                                  : Theme.of(context).textTheme.bodyLarge!.color
                               ),
                               child: Text(AppLocalizations.of(context)!.hours6),
                             ),
@@ -334,7 +334,7 @@ class _LogsQuantityPerLoadModalState extends State<LogsQuantityPerLoadModal> {
                                 fontSize: 14,
                                 color: selectedOption == 5
                                   ? Theme.of(context).colorScheme.primary
-                                  : Theme.of(context).textTheme.bodyText1!.color
+                                  : Theme.of(context).textTheme.bodyLarge!.color
                               ),
                               child: Text(AppLocalizations.of(context)!.hours8),
                             ),


### PR DESCRIPTION
I fixed the following deprecations which were reported by the dart analyzer:

- removed the androidOverscrollIndicator property since this is the [default behavior](https://stackoverflow.com/a/73510867) in material 3 now
- renamed bodyText1 to bodyLarge

Greetings from Germany ^^