### PR TITLE
fix: adjust colors of home widgets to match pihole web ui

### DIFF
--- a/lib/screens/home/home.dart
+++ b/lib/screens/home/home.dart
@@ -98,7 +98,7 @@ class _HomeState extends State<Home> {
                     child: HomeTile(
                       icon: Icons.public, 
                       iconColor: const Color.fromARGB(255, 64, 146, 66), 
-                      color: Colors.green, 
+                      color: Colors.blue, 
                       label: AppLocalizations.of(context)!.totalQueries, 
                       value: intFormat(statusProvider.getRealtimeStatus!.dnsQueriesToday,Platform.localeName),
                     ),
@@ -111,7 +111,7 @@ class _HomeState extends State<Home> {
                     child: HomeTile(
                       icon: Icons.block, 
                       iconColor: const Color.fromARGB(255, 28, 127, 208), 
-                      color: Colors.blue, 
+                      color: Colors.red, 
                       label: AppLocalizations.of(context)!.queriesBlocked, 
                       value: intFormat(statusProvider.getRealtimeStatus!.adsBlockedToday, Platform.localeName),
                     ),
@@ -137,7 +137,7 @@ class _HomeState extends State<Home> {
                     child: HomeTile(
                       icon: Icons.list, 
                       iconColor: const Color.fromARGB(255, 211, 58, 47), 
-                      color: Colors.red, 
+                      color: Colors.green, 
                       label: AppLocalizations.of(context)!.domainsAdlists, 
                       value: intFormat(statusProvider.getRealtimeStatus!.domainsBeingBlocked, Platform.localeName),
                     ),


### PR DESCRIPTION
This PR just makes changes to the color selections made for the widgets in the home screen, and change the colors to match the web interface of Pi-hole. First image shows the colors at the current version, and second image is how the colors are in the web interface.

![photo_2024-08-22_07-16-33](https://github.com/user-attachments/assets/33eba782-b1b2-42bc-a62d-1a8b17882476)
![pi-hole-web](https://github.com/user-attachments/assets/ade63f5a-3f5c-48df-b76e-58826f784399)
